### PR TITLE
Ensure proper handling of XDG_CONFIG_HOME default value

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -66,6 +66,10 @@ package() {
   echo "Name=LR2oraja" >> "$desktopEntry"
   echo "Categories=Games;" >> "$desktopEntry"
   echo "Icon=lr2oraja-icon" >> "$desktopEntry"
+  
+  if [ -z "$XDG_CONFIG_HOME" ]; then
+    XDG_CONFIG_HOME="$HOME/.config"
+  fi
 
   # Create config symlink
   ln -sfn "$pkgdir/opt/beatoraja" "$XDG_CONFIG_HOME/beatoraja"


### PR DESCRIPTION
This pull request addresses an issue with the script where the default value of `XDG_CONFIG_HOME` was not being handled correctly according to the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html). The specification states that if `XDG_CONFIG_HOME` is either not set or empty, a default value equal to `$HOME/.config` should be used.